### PR TITLE
updated company & contact seed with default avatar image. Displayed a…

### DIFF
--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -2,6 +2,9 @@
   <h1>Contacts#show</h1>
   <h1>Contact Details</h1>
   <div>
+    <div class="avatar-large">
+      <%= image_tag @contact.avatar, alt:"contact-avatar", :class => "avatar-large" %>
+    </div>
     <div>
       <h2><%= @contact.first_name if @contact.first_name %> <%= @contact.last_name if @contact.last_name %></h2>
       <p><%= @contact.job_title if @contact.job_title %></p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,8 @@ puts 'seeded user'
     address: Faker::Address.street_address,
     phone: Faker::PhoneNumber.phone_number,
     website: Faker::Internet.url,
-    linkedin: Faker::Internet.domain_name
+    linkedin: Faker::Internet.domain_name,
+    avatar: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS9eKVfG9-n89X7vmzotbHPnnLqdIJNdrGv8XQTRTnzFBPT3rAFNGy6ImFE9FoNM1_3MfI&usqp=CAU"
   )
 end
 
@@ -50,7 +51,8 @@ puts 'seeded companies'
     birthday: Faker::Date.between(from: '1970-09-23', to: '2005-09-25'),
     archive: false,
     linkedin: Faker::Internet.domain_name,
-    company: Company.order("RANDOM()").limit(1).first
+    company: Company.order("RANDOM()").limit(1).first,
+    avatar: "https://media.licdn.com/dms/image/v2/C5603AQGFsq4Z2sjOzA/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1638927273157?e=1729728000&v=beta&t=2y7V9w5wGzydguJucApw8p4gjiUXgROUgPmN2tiM62Y"
     # company: Company.all.sample
   )
 end


### PR DESCRIPTION
@Paretooptimal22 pls review
(no merge conflicts)

seeds:
- compant & contact: added a default image url to the seeds for the avatar

contacts:
- displaying the default image in the contact show page 
<img width="289" alt="image" src="https://github.com/user-attachments/assets/e36e63fc-8965-4ceb-a7e5-674a52d51c23">
