### PR TITLE
added styling to add contact to event

### DIFF
--- a/app/views/contacts/_assign_contact_form.html.erb
+++ b/app/views/contacts/_assign_contact_form.html.erb
@@ -1,0 +1,10 @@
+<%= simple_form_for EventContact.new, url: event_contacts_path do |f| %>
+  <%= f.input :contact_id, as: :hidden, input_html: { value: @contact.id } %>
+  <div class="form-group">
+    <%= f.input :event_id, collection: Event.all, prompt: "Choose an event" , label: false %>
+  </div>
+
+  <div class="form-group">
+    <%= f.button :submit, "Add to Event", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/contacts/_contact.html.erb
+++ b/app/views/contacts/_contact.html.erb
@@ -27,18 +27,3 @@
     <a href="tel:<% @contact.phone %>"><i class="fa-solid fa-phone text-primary"></i></a>
   <% end %>
 </div>
-
-<h2>Add Contact to Event</h2>
-<%= form_with(model: EventContact.new, url: event_contacts_path) do |f| %>
-  <%= f.hidden_field :contact_id, value: @contact.id %>
-
-  <div class="form-group">
-    <%= f.label :event_id, "Select Event" %>
-    <%= f.collection_select :event_id, Event.all, :id, :name, prompt: "Choose an event" %>
-  </div>
-
-  <div class="form-group">
-    <%= f.submit "Add to Event", class: "btn btn-primary" %>
-  </div>
-<% end %>
-

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -16,6 +16,24 @@
 <div class="list-container">
   <div data-controller="reset-form">
     <div class="d-flex justify-content-between align-items-center mt-3">
+      <h3>Assign Contact to Event</h3>
+      <p>
+        <a class="btn btn-primary rounded-4 shadow" data-reset-form-target="btn" data-bs-toggle="collapse" href="#collapseAssign" role="button" aria-expanded="false" aria-controls="collapseExample">
+          <i class="fa-solid fa-plus" data-navigation-target="icon"></i>
+        </a>
+      </p>
+    </div>
+    <div class="collapse" id="collapseAssign">
+      <div class="card card-body bg-white rounded-4 shadow">
+        <%= render 'contacts/assign_contact_form' %>
+      </div>
+    </div>
+</div>
+
+
+<div class="list-container">
+  <div data-controller="reset-form">
+    <div class="d-flex justify-content-between align-items-center mt-3">
       <h3>To Do's</h3>
       <p>
         <a class="btn btn-primary rounded-4 shadow" data-reset-form-target="btn" data-bs-toggle="collapse" href="#collapseTodo" role="button" aria-expanded="false" aria-controls="collapseExample">


### PR DESCRIPTION
-used a drop down like the todo and notes for uniformity and minimize usage of real estate of the page.
<img width="327" alt="Screenshot 2024-08-27 at 10 08 04" src="https://github.com/user-attachments/assets/0a7668a7-39af-493d-89f6-dbe57f9ee70c">
<img width="346" alt="Screenshot 2024-08-27 at 10 40 24" src="https://github.com/user-attachments/assets/0d4f2070-34b5-4942-81c9-006352168be8">
