### PR TITLE
todo index page

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -3,13 +3,13 @@ class TodosController < ApplicationController
     # @todos = Todo.all
     @todos = case params[:filter]
     when 'pending'
-      Todo.pending
+      Todo.pending.order(end_date: :asc)
     when 'overdue'
-      Todo.overdue
+      Todo.overdue.order(end_date: :asc)
     when 'completed'
-      Todo.completed
+      Todo.completed.order(end_date: :asc)
     else
-      Todo.all_todos
+      Todo.all_todos.order(end_date: :asc)
     end
     @page_title = "To Do's"
   end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -8,8 +8,8 @@ class Todo < ApplicationRecord
   validates_comparison_of :end_date, greater_than: Date.today
 
   # scopes
-  scope :pending, -> { where(status: false).where('end_date >= ?', Date.today) }
-  scope :overdue, -> { where(status: false).where('end_date < ?', Date.today) }
-  scope :completed, -> { where(status: true) }
+  scope :pending, -> { where(status: ["in_progress", "not_started"]).where('end_date >= ?', Date.today) }
+  scope :overdue, -> { where(status: ["in_progress", "not_started"]).where('end_date < ?', Date.today) }
+  scope :completed, -> { where(status: "done") }
   scope :all_todos, -> { all }
 end

--- a/app/views/todos/_todo_upcoming.html.erb
+++ b/app/views/todos/_todo_upcoming.html.erb
@@ -1,30 +1,30 @@
-<div class="upcoming-container">
-  <div class="btn-group p-2 d-flex justify-content-center gap-3 my-3" role="group">
+<li class="list-item card py-2  my-2 rounded-4" style="background: #F5F5FA;">
+  <div class="d-flex justify-content-between align-items-center">
+    <div class="card-left ps-4 d-flex">
+        <i style="font-size: 2rem; color: #7ce7ac; min-height: 4rem" class="card d-flex align-items-center justify-content-center fa-solid fa-clipboard-list px-4 me-2 bg-white rounded-4"></i>
+      <div class="card-left-content">
+        <h4><strong><%= todo.name %></strong></h4>
 
-    <%= link_to "All", todos_path(filter: 'all'), class:"btn btn-outline-secondary btn-lg todo-status-button" %>
-    <%= link_to "Pending", todos_path(filter: 'pending'), class:"btn btn-outline-primary btn-lg todo-status-button" %>
-    <%= link_to "Overdue", todos_path(filter: 'overdue'), class:"btn btn-outline-warning btn-lg todo-status-button" %>
-    <%= link_to "Completed", todos_path(filter: 'completed'), class:"btn btn-outline-success btn-lg todo-status-button" %>
-  </div>
 
-  <div class="upcoming-list-container rounded-4 shadow " style="max-height: 70vh; overflow: auto;">
-    <ul class="list-group bg-white  rounded-4 p-4">
-      <% @todos.each do |todo| %>
-        <li class="list-item card py-2 my-2 rounded-4" style="background: #F5F5FA;">
-          <div class="d-flex justify-content-between align-items-center">
-            <div class="card-left ps-4 d-flex">
-                <i style="font-size: 2rem; color: #7ce7ac" class="card d-flex align-items-center justify-content-center fa-solid fa-clipboard-list px-4 me-2 bg-white rounded-4"></i>
-              <div class="card-left-content">
-                <h4><strong><%= todo.name %></strong></h4>
-                <h5>status: <%= todo.status %></h5>
-              </div>
-            </div>
-            <div class="card-left pe-4">
-              <h4 class="border p-2 rounded-pill bg-white"><%= todo.end_date %></h4>
-            </div>
-          </div>
-        </li>
-      <% end %>
-    </ul>
+        <%# Logic to display username and/or company name %>
+        <% if todo.todoable_type == "Contact" %>
+          <h5>Contact:
+            <%= todo.todoable.first_name if todo.todoable.first_name != nil %>
+            <%= todo.todoable.last_name if todo.todoable.last_name != nil %>
+          </h5>
+        <% end %>
+        <% if todo.todoable_type == "Contact" && todo.todoable.company.name != 0 %>
+          <%# <h5>Company: <%= todo.todoable.company.name %>
+        <% end %>
+        <% if todo.todoable_type == "Company" %>
+          <h5>Company: <%= todo.todoable.name if todo.todoable.name != nil %></h5>
+        <% end %>
+
+      </div>
+    </div>
+
+    <div class="card-left pe-4">
+      <h4 class="border p-2 rounded-pill bg-white"><%= todo.end_date.strftime("%m/%d") %></h4>
+    </div>
   </div>
-</div>
+</li>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,2 +1,36 @@
+<div class="upcoming-container">
 
-<%= render 'todos/todo_upcoming' %>
+
+  <div class="btn-group p-2 d-flex justify-content-center gap-3 my-3" role="group">
+
+    <%= link_to "Pending", todos_path(filter: 'pending'), class:"btn btn-outline-primary btn-lg todo-status-button" %>
+    <%= link_to "Overdue", todos_path(filter: 'overdue'), class:"btn btn-outline-warning btn-lg todo-status-button" %>
+    <%= link_to "Completed", todos_path(filter: 'completed'), class:"btn btn-outline-success btn-lg todo-status-button" %>
+    <%= link_to "All", todos_path(filter: 'all'), class:"btn btn-outline-secondary btn-lg todo-status-button" %>
+
+  </div>
+
+  <div class="upcoming-list-container rounded-4 shadow " style="max-height: 70vh; overflow: auto;">
+    <ul class="list-group bg-white  rounded-4 p-4">
+      <% @todos.each do |todo| %>
+        <% if todo.todoable_type == "Contact" %>
+          <%= link_to contact_path(todo.todoable) do %>
+            <%# Rendering to do's attached to a contact %>
+            <%= render 'todos/todo_upcoming', todo: todo %>
+          <% end %>
+
+        <% elsif todo.todoable_type == "Company" %>
+          <%= link_to company_path(todo.todoable) do %>
+          <%# Rendering to do's attached to a company %>
+          <%= render 'todos/todo_upcoming', todo: todo %>
+        <% end %>
+
+         <% else%>
+          <%# Rendering all remaining to do's %>
+          <%= render 'todos/todo_upcoming', todo: todo %>
+        <% end %>
+      <% end %>
+
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
@Paretooptimal22 pls review

Todo Index page
- sorted todos by due date ascending
- updated order of filter buttons
- made filter buttons match the status we set in the backend
- displaying contact name of company name (depending on who it's linked to)
- turned the todo cards into links (to contact or company, depending on who it's linked to)
- shortened date (removed year), to make more space in the card and avoid it expanding

<img width="291" alt="image" src="https://github.com/user-attachments/assets/e844afb3-9234-4cd2-bfe7-5b0403bd5b59">
